### PR TITLE
REWIND-91: Added UnitTestPlan + almost fully implemented unit tests for QuoteCreationViewModel

### DIFF
--- a/Rewind/Project.swift
+++ b/Rewind/Project.swift
@@ -66,11 +66,12 @@ let project = Project(
             name: "Rewind",
             shared: true,
             buildAction: .buildAction(targets: ["Rewind"]),
-            testAction: .testPlans(["Rewind/UITests/UITestPlan.xctestplan"]),
+            testAction: .testPlans(["Rewind/Tests/UnitTestPlan.xctestplan", "Rewind/UITests/UITestPlan.xctestplan"]),
             runAction: .runAction(executable: "Rewind")
         )
     ],
     additionalFiles: [
+        "Rewind/Tests/UnitTestPlan.xctestplan",
         "Rewind/UITests/UITestPlan.xctestplan",
     ]
 )

--- a/Rewind/Rewind/Tests/QuoteCreationViewModelTests.swift
+++ b/Rewind/Rewind/Tests/QuoteCreationViewModelTests.swift
@@ -1,0 +1,76 @@
+import Testing
+@testable import Features
+
+@MainActor
+struct QuoteCreationViewModelTests {
+    
+    typealias QuoteState = QuoteCreationViewModel.QuoteState
+    
+    private var vm: QuoteCreationViewModel!
+    
+    init() {
+        vm = .init()
+    }
+    
+    @Test(arguments: [
+        ("", "", QuoteState.empty),
+        ("q", "", QuoteState.empty),
+        ("", "a", QuoteState.empty),
+        ("q", "a", QuoteState.ready)
+    ])
+    func testQuoteState(quote: String, author: String, expected: QuoteState) {
+        vm.quote = quote
+        vm.author = author
+        
+        #expect(vm.quoteState == expected)
+    }
+    
+    @Test
+    func testPresentQuoteInput() {
+        vm.dispatch(.presentQuoteInput)
+        
+        #expect(vm.quoteInputPresented == true)
+    }
+    
+    @Test(arguments: [
+        ("", false),
+        ("aboba", true)
+    ])
+    func testPresentAuthorInput(quote: String, expectedAuthorInputPresented: Bool) {
+        vm.quote = quote
+        
+        vm.dispatch(.presentAuthorInput)
+        
+        #expect(vm.authorInputPresented == expectedAuthorInputPresented)
+    }
+    
+    @Test(arguments: [
+        ("", "", true),
+        ("q", "a", false)
+    ])
+    func testDismissAll(quote: String, author: String, expectedQuoteInputPresented: Bool) {
+        vm.quote = quote
+        vm.author = author
+        vm.quoteInputPresented = true
+        
+        vm.dispatch(.dismissAll)
+        
+        #expect(vm.quoteInputPresented == expectedQuoteInputPresented)
+    }
+    
+    @Test
+    func testSaveQuotePrintsSomething() {
+        // TODO: will be here later
+    }
+    
+    @Test
+    func testResetQuote() {
+        vm.quote = "q"
+        vm.author = "a"
+        
+        vm.dispatch(.resetQuote)
+        
+        #expect(vm.quote.isEmpty)
+        #expect(vm.author.isEmpty)
+    }
+}

--- a/Rewind/Rewind/Tests/RewindTests.swift
+++ b/Rewind/Rewind/Tests/RewindTests.swift
@@ -1,8 +1,0 @@
-import Foundation
-import XCTest
-
-final class RewindTests: XCTestCase {
-    func test_twoPlusTwo_isFour() {
-        XCTAssertEqual(2+2, 4)
-    }
-}

--- a/Rewind/Rewind/Tests/UnitTestPlan.xctestplan
+++ b/Rewind/Rewind/Tests/UnitTestPlan.xctestplan
@@ -1,0 +1,33 @@
+{
+  "configurations" : [
+    {
+      "id" : "D969D41F-F002-421B-BE13-A96740EE1C14",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : {
+      "targets" : [
+        {
+          "containerPath" : "container:Modules\/Features\/Features.xcodeproj",
+          "identifier" : "C2829F0E3A10F31ED8B78458",
+          "name" : "Features"
+        }
+      ]
+    },
+    "distributor" : "com.apple.TestFlight"
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:Rewind.xcodeproj",
+        "identifier" : "9BCECF31967EA62C77CA76FA",
+        "name" : "RewindTests"
+      }
+    }
+  ],
+  "version" : 1
+}


### PR DESCRIPTION
Появился новый тест план:

<img width="1205" alt="Screenshot 2025-05-12 at 02 31 38" src="https://github.com/user-attachments/assets/addc8d1f-b555-4ccc-bf9d-3510d90e1e47" />

Тесты не супер пупер классные, но почти всё покрыли и будто здорово. Не покрыт только кусочек:

<img width="906" alt="image" src="https://github.com/user-attachments/assets/0a4eadb4-57cd-48c5-bd86-6d172d0ac269" />