### PR TITLE
REWIND-100: Rewrote navigation on ZStack + minor fixes

### DIFF
--- a/Rewind/Modules/Features/Sources/Account/AccountRouter.swift
+++ b/Rewind/Modules/Features/Sources/Account/AccountRouter.swift
@@ -9,4 +9,8 @@ public final class AccountRouter {
     func navigateToWelcome() {
         appRouter?.navigate(to: .welcome)
     }
+    
+    func dismiss() {
+        appRouter?.pop()
+    }
 }

--- a/Rewind/Modules/Features/Sources/Account/AccountView.swift
+++ b/Rewind/Modules/Features/Sources/Account/AccountView.swift
@@ -14,8 +14,6 @@ public struct AccountView: View {
     
     @State private var genericSheetItem: GenericInputSheetItem?
     
-    @Environment(\.dismiss)
-    private var dismiss
     @Environment(\.showToast)
     private var showToast
     
@@ -31,14 +29,14 @@ public struct AccountView: View {
             ScrollView {
                 VStack(spacing: 15) {
                     avatar.onTapGesture {
-                            withAnimation(.spring(response: 0.2)) {
-                                guard viewModel.user.imageData != nil else {
-                                    photoPickerShown = true
-                                    return
-                                }
-                                blurredAvatarShown = true
+                        withAnimation(.spring(response: 0.2)) {
+                            guard viewModel.user.imageData != nil else {
+                                photoPickerShown = true
+                                return
                             }
+                            blurredAvatarShown = true
                         }
+                    }
                     
                     groupsTable
                     
@@ -136,7 +134,7 @@ public struct AccountView: View {
     
     var header: some View {
         RewindHeader {
-            RewindButton(type: .leftChevron) { dismiss() }
+            RewindButton(type: .leftChevron) { viewModel.router.dismiss() }
         } centerView: {
             HeaderBadgeView(
                 image: viewModel.user.image,
@@ -148,7 +146,7 @@ public struct AccountView: View {
     }
     
     var avatar: some View {
-      AvatarView(image: viewModel.user.image, text: viewModel.user.name)
+        AvatarView(image: viewModel.user.image, text: viewModel.user.name)
     }
     
     var appIconsTable: some View {

--- a/Rewind/Modules/Features/Sources/Authentication/AuthenticationRouting/AuthenticationRouter.swift
+++ b/Rewind/Modules/Features/Sources/Authentication/AuthenticationRouting/AuthenticationRouter.swift
@@ -35,4 +35,8 @@ public final class AuthenticationRouter {
     func dismiss(by count: Int) {
         appRouter?.pop(by: count)
     }
+    
+    func dismiss() {
+        appRouter?.pop()
+    }
 }

--- a/Rewind/Modules/Features/Sources/Authentication/CodeInput/CodeInputView.swift
+++ b/Rewind/Modules/Features/Sources/Authentication/CodeInput/CodeInputView.swift
@@ -2,11 +2,8 @@ import SwiftUI
 import UIComponents
 
 public struct CodeInputView: View {
-    @State var viewModel: CodeInputViewModel
+    @State private var viewModel: CodeInputViewModel
     @State private var code: [String] = Array(repeating: "", count: 4)
-    
-    @Environment(\.dismiss)
-    private var dismiss
     
     public init(router: AuthenticationRouter, email: String, registrationID: String) {
         viewModel = .init(router: router, email: email, registrationID: registrationID)
@@ -16,9 +13,14 @@ public struct CodeInputView: View {
         ZStack(alignment: .topLeading) {
             Color.background.ignoresSafeArea()
             
-            RewindHeader {
-                RewindButton(type: .leftChevron) { dismiss() }
-            }
+            RewindHeader(leftView: {
+                RewindButton(type: .leftChevron) {
+                    hideKeyboard()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + AuthConstants.keyboardHideDelay) {
+                        viewModel.router.dismiss()
+                    }
+                }
+            })
             
             VStack(alignment: .center, spacing: AuthConstants.fieldSpacing) {
                 Text(UIComponentsStrings.Code.title)

--- a/Rewind/Modules/Features/Sources/Authentication/EmailInput/EmailInputView.swift
+++ b/Rewind/Modules/Features/Sources/Authentication/EmailInput/EmailInputView.swift
@@ -3,11 +3,8 @@ import UIComponents
 import AccessibilitySupport
 
 public struct EmailInputView: View {
-    @State var viewModel: EmailInputViewModel
+    @State private var viewModel: EmailInputViewModel
     @FocusState private var isFocused: Bool
-    
-    @Environment(\.dismiss)
-    private var dismiss
     
     public init(flow: AuthFlow, router: AuthenticationRouter) {
         viewModel = .init(flow: flow, router: router)
@@ -17,9 +14,14 @@ public struct EmailInputView: View {
         ZStack(alignment: .topLeading) {
             Color.background.ignoresSafeArea()
             
-            RewindHeader {
-                RewindButton(type: .leftChevron) { dismiss() }
-            }
+            RewindHeader(leftView: {
+                RewindButton(type: .leftChevron) {
+                    hideKeyboard()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + AuthConstants.keyboardHideDelay) {
+                        viewModel.router.dismiss()
+                    }
+                }
+            })
             
             VStack(alignment: .center, spacing: AuthConstants.fieldSpacing) {
                 Text(UIComponentsStrings.Email.title)
@@ -49,7 +51,9 @@ public struct EmailInputView: View {
             .modifier(VStackTopOffsetModifier(topOffsetRatio: AuthConstants.contentTopOffsetRatio))
         }
         .onAppear {
-            isFocused = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + AuthConstants.keyboardFocusDelay) {
+                isFocused = true
+            }
         }
         .hideKeyboardOnTap()
         .hideKeyboardOnDrag()

--- a/Rewind/Modules/Features/Sources/Authentication/NameInput/NameInputView.swift
+++ b/Rewind/Modules/Features/Sources/Authentication/NameInput/NameInputView.swift
@@ -2,12 +2,9 @@ import SwiftUI
 import UIComponents
 
 public struct NameInputView: View {
-    @State var viewModel: NameInputViewModel
+    @State private var viewModel: NameInputViewModel
     @State private var name: String = ""
     @FocusState private var isFocused: Bool
-    
-    @Environment(\.dismiss)
-    private var dismiss
     
     public init(router: AuthenticationRouter, email: String, password: String, registrationID: String) {
         viewModel = .init(router: router, email: email, password: password, registrationID: registrationID)
@@ -17,9 +14,14 @@ public struct NameInputView: View {
         ZStack(alignment: .topLeading) {
             Color.background.ignoresSafeArea()
             
-            RewindHeader {
-                RewindButton(type: .leftChevron) { dismiss() }
-            }
+            RewindHeader(leftView: {
+                RewindButton(type: .leftChevron) {
+                    hideKeyboard()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + AuthConstants.keyboardHideDelay) {
+                        viewModel.router.dismiss()
+                    }
+                }
+            })
             
             VStack(alignment: .center, spacing: AuthConstants.fieldSpacing) {
                 Text(UIComponentsStrings.Name.title)
@@ -48,7 +50,9 @@ public struct NameInputView: View {
             .modifier(VStackTopOffsetModifier(topOffsetRatio: AuthConstants.contentTopOffsetRatio))
         }
         .onAppear {
-            isFocused = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + AuthConstants.keyboardFocusDelay) {
+                isFocused = true
+            }
         }
         .hideKeyboardOnTap()
         .hideKeyboardOnDrag()

--- a/Rewind/Modules/Features/Sources/Authentication/PasswordInput/PasswordInputView.swift
+++ b/Rewind/Modules/Features/Sources/Authentication/PasswordInput/PasswordInputView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import UIComponents
 
 public struct PasswordInputView: View {
-    @State var viewModel: PasswordInputViewModel
+    @State private var viewModel: PasswordInputViewModel
     @State private var showNotice = false
     @State private var canResend = false
     @State private var timer: Timer? = nil
@@ -17,8 +17,9 @@ public struct PasswordInputView: View {
         ZStack(alignment: .topLeading) {
             Color.background.ignoresSafeArea()
             
-            RewindHeader {
-                RewindButton(type: .leftChevron) {
+            RewindButton(type: .leftChevron) {
+                hideKeyboard()
+                DispatchQueue.main.asyncAfter(deadline: .now() + AuthConstants.keyboardHideDelay) {
                     Task {
                         await viewModel.dispatch(.dismiss)
                     }
@@ -62,7 +63,9 @@ public struct PasswordInputView: View {
             .modifier(VStackTopOffsetModifier(topOffsetRatio: AuthConstants.contentTopOffsetRatio))
         }
         .onAppear {
-            isFocused = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + AuthConstants.keyboardFocusDelay) {
+                isFocused = true
+            }
         }
         .hideKeyboardOnTap()
         .hideKeyboardOnDrag()

--- a/Rewind/Modules/Features/Sources/Gallery/GalleryRouter/GalleryRouter.swift
+++ b/Rewind/Modules/Features/Sources/Gallery/GalleryRouter/GalleryRouter.swift
@@ -19,4 +19,8 @@ public final class GalleryRouter {
     func navigateToMediaDetails(_ image: UIImage) {
         appRouter?.navigate(to: .mediaDetails(image))
     }
+    
+    func dismiss() {
+        appRouter?.pop()
+    }
 }

--- a/Rewind/Modules/Features/Sources/Gallery/GalleryView.swift
+++ b/Rewind/Modules/Features/Sources/Gallery/GalleryView.swift
@@ -5,10 +5,7 @@ public struct GalleryView: View {
     @State private var isBlurredMediaPresented = false
     @State private var selectedMedia: UIImage?
     
-    let router: GalleryRouter
-    
-    @Environment(\.dismiss)
-    private var dismiss
+    private let router: GalleryRouter
     
     public init(router: GalleryRouter) {
         self.router = router
@@ -19,6 +16,11 @@ public struct GalleryView: View {
             GalleryHeader(
                 image: UIComponentsAsset.media5.image,
                 groupName: "Group name",
+                onDismiss: {
+                    DispatchQueue.main.async {
+                        router.dismiss()
+                    }
+                },
                 onAddingQuote: router.navigateToQuoteCreation,
                 onAddingMedia: router.navigateToMediaLoading
             )
@@ -81,7 +83,7 @@ public struct GalleryView: View {
                 
                 Spacer()
                 
-                RewindMediaButton(size: 60, fontSize: 28, type: .rewind) { dismiss() }
+                RewindMediaButton(size: 60, fontSize: 28, type: .rewind) { router.dismiss() }
                 
                 Spacer()
                 

--- a/Rewind/Modules/Features/Sources/Gallery/MediasUploading/MediasUploadingView.swift
+++ b/Rewind/Modules/Features/Sources/Gallery/MediasUploading/MediasUploadingView.swift
@@ -6,77 +6,80 @@ import Domain
 public struct MediasUploadingView: View {
     @State var viewModel: MediasUploadingViewModel
     
-    @Environment(\.dismiss)
-    private var dismiss
+    private let router: AppRouter
+    
     @Environment(\.showToast)
     private var showToast
     
-    public init() {
+    public init(router: AppRouter) {
         viewModel = .init()
+        self.router = router
     }
     
     public var body: some View {
-        VStack(spacing: 0) {
-            header
-            
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 10) {
-                    ForEach(viewModel.loadedMedias) { loadedMedia in
-                        loadedMedia.makeView()
-                            .overlay {
-                                badges(for: loadedMedia) {
-                                    Task {
-                                        await viewModel.dispatch(.removeMedia(loadedMedia))
+        NavigationStack {
+            VStack(spacing: 0) {
+                header
+                
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 10) {
+                        ForEach(viewModel.loadedMedias) { loadedMedia in
+                            loadedMedia.makeView()
+                                .overlay {
+                                    badges(for: loadedMedia) {
+                                        Task {
+                                            await viewModel.dispatch(.removeMedia(loadedMedia))
+                                        }
                                     }
                                 }
-                            }
-                            .onTapGesture {
-                                Task {
-                                    await viewModel.dispatch(.showMediaSettings(loadedMedia))
+                                .onTapGesture {
+                                    Task {
+                                        await viewModel.dispatch(.showMediaSettings(loadedMedia))
+                                    }
                                 }
-                            }
+                        }
+                        
+                        photosPicker
                     }
-                    
-                    photosPicker
+                    .padding(.horizontal, 10)
                 }
-                .padding(.horizontal, 10)
-            }
-            .padding(.vertical, 10)
-            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-            .background(Color.backgroundSecondary)
-            .cornerRadius(32)
-            .padding(.bottom, 8)
-            
-            settingsToggle
-                .padding(.bottom, 16)
-            
-            Group {
-                musicSection
+                .padding(.vertical, 10)
+                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                .background(Color.backgroundSecondary)
+                .cornerRadius(32)
+                .padding(.bottom, 8)
+                
+                settingsToggle
                     .padding(.bottom, 16)
                 
-                TagsSectionView(tags: $viewModel.tags)
-            }.disabledWithOpacity(!viewModel.similarSettigns)
-            
-            Spacer()
-        }
-        .navigationDestination(item: $viewModel.viewingMedia) { media in
-            mediaSettings(for: media)
-        }
-        .onAppear {
-            viewModel.set(showToast: showToast)
-        }
-        .padding(.horizontal, 8)
-        .background(Color.background)
-        .onChange(of: viewModel.selection) { _, newItems in
-            Task {
-                await viewModel.dispatch(.importMedias(newItems))
+                Group {
+                    musicSection
+                        .padding(.bottom, 16)
+                    
+                    TagsSectionView(tags: $viewModel.tags)
+                }.disabledWithOpacity(!viewModel.similarSettigns)
+                
+                Spacer()
+            }
+            .navigationDestination(item: $viewModel.viewingMedia) { media in
+                mediaSettings(for: media)
+            }
+            .onAppear {
+                viewModel.set(showToast: showToast)
+            }
+            .padding(.horizontal, 8)
+            .background(Color.background)
+            .onChange(of: viewModel.selection) { _, newItems in
+                Task {
+                    await viewModel.dispatch(.importMedias(newItems))
+                }
             }
         }
     }
     
     private var header: some View {
         RewindHeader(leftView: {
-            RewindButton(type: .leftChevron) { dismiss() }
+            RewindButton(type: .leftChevron) { router.pop() }
         })
     }
     
@@ -104,8 +107,8 @@ public struct MediasUploadingView: View {
                 trackName: "OVER",
                 artist: "Playboi Carti"
             ) {}
-            .background(Color.backgroundSecondary)
-            .cornerRadius(25)
+                .background(Color.backgroundSecondary)
+                .cornerRadius(25)
         }
     }
     

--- a/Rewind/Modules/Features/Sources/Gallery/QuoteCreation/QuoteCreationView.swift
+++ b/Rewind/Modules/Features/Sources/Gallery/QuoteCreation/QuoteCreationView.swift
@@ -7,12 +7,14 @@ public struct QuoteCreationView: View {
     @State var backgroundColor: Color = .random
     @State var textColor: Color = .random
     
-    @Environment(\.dismiss)
-    private var dismiss
     @Environment(\.showToast)
     private var showToast
     
-    public init() {}
+    private let router: AppRouter
+    
+    public init(router: AppRouter) {
+        self.router = router
+    }
     
     public var body: some View {
         VStack(spacing: 0) {
@@ -45,7 +47,7 @@ public struct QuoteCreationView: View {
     
     private var header: some View {
         RewindHeader {
-            RewindButton(type: .leftChevron) { dismiss() }
+            RewindButton(type: .leftChevron) { router.pop() }
         } rightView: {
             RewindButton(type: .trash) {
                 guard viewModel.quoteState != .empty else { return }
@@ -64,7 +66,7 @@ public struct QuoteCreationView: View {
             .aspectRatio(1, contentMode: .fit)
             .foregroundColor(
                 viewModel.quoteState == .empty ?
-                .backgroundSecondary : backgroundColor
+                    .backgroundSecondary : backgroundColor
             )
             .overlay {
                 switch viewModel.quoteState {
@@ -152,12 +154,8 @@ public struct QuoteCreationView: View {
             viewModel.dispatch(.saveQuote(AnyView(quoteContent)))
             
             showToast(UIComponentsStrings.Quote.Toast.success)
-            dismiss()
+            router.pop()
         }
         .disabledWithOpacity(viewModel.quoteState == .empty)
     }
-}
-
-#Preview {
-    QuoteCreationView()
 }

--- a/Rewind/Modules/Features/Sources/Map/RewindsMap/RewindsMap.swift
+++ b/Rewind/Modules/Features/Sources/Map/RewindsMap/RewindsMap.swift
@@ -3,16 +3,16 @@ import MapKit
 import UIComponents
 
 public struct RewindsMap: View {
-    @State var viewModel: RewindsMapViewModel
-    @State var badgeWidth: CGFloat = .zero
+    @State private var viewModel: RewindsMapViewModel
+    @State private var badgeWidth: CGFloat = .zero
     
     @State private var isRewindsListPresented = false
     
-    @Environment(\.dismiss)
-    private var dismiss
+    private let router: AppRouter
     
-    public init() {
+    public init(router: AppRouter) {
         viewModel = RewindsMapViewModel()
+        self.router = router
     }
     
     public var body: some View {
@@ -79,7 +79,7 @@ public struct RewindsMap: View {
                 .frame(maxWidth: .infinity, maxHeight: 70)
             
             HStack {
-                makeButton("chevron.left") { dismiss() }
+                makeButton("chevron.left") { router.pop() }
                 Spacer()
                 RoundedRectangle(cornerRadius: 15)
                     .frame(height: 54)
@@ -130,8 +130,4 @@ public struct RewindsMap: View {
                 }
         }
     }
-}
-
-#Preview {
-    RewindsMap()
 }

--- a/Rewind/Modules/Features/Sources/MediaDetails/MediaDetailsView.swift
+++ b/Rewind/Modules/Features/Sources/MediaDetails/MediaDetailsView.swift
@@ -3,11 +3,11 @@ import UIComponents
 
 public struct MediaDetailsView: View {
     @State var tags: [String] = []
+    private let router: AppRouter
     var image: UIImage
     
-    @Environment(\.dismiss) private var dismiss
-
-    public init(image: UIImage) {
+    public init(router: AppRouter, image: UIImage) {
+        self.router = router
         self.image = image
     }
     
@@ -37,7 +37,7 @@ public struct MediaDetailsView: View {
     
     private var header: some View {
         RewindHeader {
-            RewindButton(type: .leftChevron) { dismiss() }
+            RewindButton(type: .leftChevron) { router.pop() }
         } centerView: {
             Text(UIComponentsStrings.MediaDetails.title)
                 .modifier(RoundFontModifier(size: AccountConstants.defaultFontSize, weight: .bold))
@@ -62,8 +62,4 @@ public struct MediaDetailsView: View {
     private var riskyTable: some View {
         InformationTable(title: UIComponentsStrings.MediaDetails.risky, data: AccountConstants.risky, isRisky: true)
     }
-}
-
-#Preview {
-    MediaDetailsView(image: UIComponentsAsset.avatar.image)
 }

--- a/Rewind/Modules/Features/Sources/Rewind/RewindRouter/RewindRouter.swift
+++ b/Rewind/Modules/Features/Sources/Rewind/RewindRouter/RewindRouter.swift
@@ -9,7 +9,7 @@ public final class RewindRouter {
     }
     
     func navigateToGallery() {
-        appRouter?.navigate(to: .gallery)
+        appRouter?.navigate(to: .gallery, with: .pushFromBottom)
     }
     
     func navigateToAccount() {

--- a/Rewind/Modules/Features/Sources/Rewind/RewindView.swift
+++ b/Rewind/Modules/Features/Sources/Rewind/RewindView.swift
@@ -7,7 +7,7 @@ public struct RewindView: View {
     @State private var currentIndex = 0
     @State private var isSelectGroupPresented = false
     
-    let router: RewindRouter
+    private let router: RewindRouter
     
     @Environment(\.showToast)
     private var showToast

--- a/Rewind/Modules/Features/Sources/Root/RootView.swift
+++ b/Rewind/Modules/Features/Sources/Root/RootView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+public struct RootView: View {
+    @Bindable var router: AppRouter
+    
+    public init(router: AppRouter) {
+        self.router = router
+    }
+    
+    public var body: some View {
+        ZStack {
+            ForEach(Array(router.stack.enumerated()), id: \.element.id) { index, wrapper in
+                let isBelowTop = index == router.stack.count - 2
+                
+                screen(for: wrapper.route)
+                    .transition(transition(for: wrapper.transition))
+                    .zIndex(Double(index))
+                
+                    .overlay {
+                        if isBelowTop {
+                            Color.black.opacity(0.2)
+                                .ignoresSafeArea()
+                                .transition(.opacity)
+                        }
+                    }
+            }
+        }
+        .animation(.easeInOut(duration: 0.35), value: router.stack)
+    }
+    
+    // the same order of cases as in AppRouter.Route enum
+    @ViewBuilder
+    private func screen(for route: AppRouter.Route) -> some View {
+        switch route {
+        case .welcome: WelcomeView(router: AuthenticationRouter(appRouter: router))
+            
+        case let .email(flow): EmailInputView(flow: flow, router: AuthenticationRouter(appRouter: router))
+        case let .code(email, registrationID): CodeInputView(router: AuthenticationRouter(appRouter: router), email: email, registrationID: registrationID)
+        case let .password(flow, registrationID): PasswordInputView(flow: flow, router: AuthenticationRouter(appRouter: router), registrationID: registrationID)
+        case let .name(email, password, registrationID): NameInputView(router: AuthenticationRouter(appRouter: router), email: email, password: password, registrationID: registrationID)
+            
+        case .rewind: RewindView(router: RewindRouter(appRouter: router))
+        case .map: RewindsMap(router: router)
+            
+        case .account: AccountView(router: AccountRouter(appRouter: router))
+        case .gallery: GalleryView(router: GalleryRouter(appRouter: router))
+        case .quoteCreation: QuoteCreationView(router: router)
+        case .mediaLoading: MediasUploadingView(router: router)
+        case let .mediaDetails(image): MediaDetailsView(router: router, image: image)
+        }
+    }
+    
+    private func transition(for style: AppRouter.TransitionStyle) -> AnyTransition {
+        switch style {
+        case .pushFromRight: return .move(edge: .trailing)
+        case .pushFromLeft: return .move(edge: .leading)
+        case .pushFromBottom: return .move(edge: .bottom)
+        case .none: return .identity
+        }
+    }
+}

--- a/Rewind/Modules/Features/Sources/Routing/AppRouter.swift
+++ b/Rewind/Modules/Features/Sources/Routing/AppRouter.swift
@@ -3,6 +3,16 @@ import Domain
 
 @MainActor @Observable
 public final class AppRouter {
+    public struct RouteWrapper: Identifiable, Equatable {
+        public let id = UUID()
+        public let route: Route
+        public let transition: TransitionStyle
+    }
+    
+    public enum TransitionStyle {
+        case pushFromRight, pushFromLeft, pushFromBottom, none
+    }
+    
     public enum Route: Hashable {
         case welcome
         
@@ -21,23 +31,24 @@ public final class AppRouter {
         case mediaDetails(UIImage)
     }
     
-    public var path = NavigationPath()
+    public var stack: [RouteWrapper] = []
     
     public init() {}
     
-    func navigate(to route: Route) {
-        path.append(route)
+    public func setInitial(_ route: Route) {
+        stack = [.init(route: route, transition: .none)]
+    }
+    
+    func navigate(to route: Route, with transition: TransitionStyle = .pushFromRight) {
+        stack.append(.init(route: route, transition: transition))
     }
     
     func pop() {
-        path.removeLast()
+        pop(by: 1)
     }
     
     func pop(by count: Int) {
-        path.removeLast(count)
-    }
-    
-    func popToRoot() {
-        path.removeLast(path.count)
+        guard count > 0, count <= stack.count - 1 else { return }
+        stack.removeLast(count)
     }
 }

--- a/Rewind/Modules/Features/Sources/Welcome/WelcomeView.swift
+++ b/Rewind/Modules/Features/Sources/Welcome/WelcomeView.swift
@@ -5,7 +5,7 @@ import Base
 public struct WelcomeView: View {
     @State private var textWidth: CGFloat = 0
     
-    let router: AuthenticationRouter
+    private let router: AuthenticationRouter
     
     public init(router: AuthenticationRouter) {
         self.router = router

--- a/Rewind/Modules/UIComponents/Sources/CodeInput/CodeInputTextField.swift
+++ b/Rewind/Modules/UIComponents/Sources/CodeInput/CodeInputTextField.swift
@@ -10,7 +10,7 @@ public struct CodeInputTextField: View {
     var onCodeFilled: () -> Void
     
     @State
-    private var focusedField: Int = 0
+    private var focusedField: Int = -1
     
     public init(
         code: Binding<[String]>,
@@ -45,6 +45,11 @@ public struct CodeInputTextField: View {
         .onChange(of: joinedCode.count == 4) { _, newValue in
             if newValue {
                 onCodeFilled()
+            }
+        }
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + AuthConstants.keyboardFocusDelay) {
+                focusedField = 0
             }
         }
     }

--- a/Rewind/Modules/UIComponents/Sources/Common/RewindHeader.swift
+++ b/Rewind/Modules/UIComponents/Sources/Common/RewindHeader.swift
@@ -6,9 +6,6 @@ public struct RewindHeader<LeftContent: View, CenterContent: View, RightContent:
     private let centerView: CenterContent
     private let rightView: RightContent
     
-    @Environment(\.dismiss)
-    private var dismiss
-
     public init(
         backgroundColor: Color = Color.background,
         @ViewBuilder leftView: () -> LeftContent = { EmptyView() },

--- a/Rewind/Modules/UIComponents/Sources/Constants/AuthConstants.swift
+++ b/Rewind/Modules/UIComponents/Sources/Constants/AuthConstants.swift
@@ -4,4 +4,6 @@ public enum AuthConstants {
     public static let fieldSpacing: CGFloat = 21
     public static let titleFontSize: CGFloat = 15
     public static let contentTopOffsetRatio: CGFloat = 0.4
+    public static let keyboardFocusDelay = 0.35
+    public static let keyboardHideDelay = 0.1
 }

--- a/Rewind/Modules/UIComponents/Sources/Extensions/View+Keyboard.swift
+++ b/Rewind/Modules/UIComponents/Sources/Extensions/View+Keyboard.swift
@@ -8,9 +8,7 @@ public extension View {
     func hideKeyboardOnDrag() -> some View {
         self.modifier(HideKeyboardOnDragModifier())
     }
-}
-
-extension View {
+    
     func hideKeyboard() {
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
     }

--- a/Rewind/Modules/UIComponents/Sources/Gallery/GalleryHeader.swift
+++ b/Rewind/Modules/UIComponents/Sources/Gallery/GalleryHeader.swift
@@ -3,27 +3,27 @@ import SwiftUI
 public struct GalleryHeader: View {
     private let image: UIImage
     private let groupName: String
+    private let onDismiss: () -> Void
     private let onAddingQuote: () -> Void
     private let onAddingMedia: () -> Void
-    
-    @Environment(\.dismiss)
-    private var dismiss
     
     public init(
         image: UIImage,
         groupName: String,
+        onDismiss: @escaping () -> Void,
         onAddingQuote: @escaping () -> Void,
         onAddingMedia: @escaping () -> Void
     ) {
         self.image = image
         self.groupName = groupName
+        self.onDismiss = onDismiss
         self.onAddingQuote = onAddingQuote
         self.onAddingMedia = onAddingMedia
     }
     
     public var body: some View {
         RewindHeader {
-            RewindButton(type: .leftChevron) { dismiss() }
+            RewindButton(type: .leftChevron) { onDismiss() }
         } centerView: {
             HeaderBadgeView(
                 image: image,

--- a/Rewind/Modules/UIComponents/Sources/Stand/StandView.swift
+++ b/Rewind/Modules/UIComponents/Sources/Stand/StandView.swift
@@ -16,9 +16,6 @@ public struct StandView: View {
     private let title: String
     private let counterType: CounterType
     
-    @Environment(\.dismiss)
-    private var dismiss
-    
     public init(title: String, counterType: CounterType) {
         self.title = title
         self.counterType = counterType
@@ -88,7 +85,7 @@ public struct StandView: View {
     private var header: some View {
         RewindHeader(backgroundColor: .clear, rightView: {
             RewindButton(type: .rightChevron, tint: .white) {
-                dismiss()
+                // TODO: dismiss
             }
         })
     }

--- a/Rewind/Rewind/Sources/RewindApp.swift
+++ b/Rewind/Rewind/Sources/RewindApp.swift
@@ -22,20 +22,15 @@ struct RewindApp: App {
             
             let testingAuth = CommandLine.arguments.contains("-testingAuth")
             
-            NavigationStack(path: $appRouter.path) {
-                Group {
-                    if isAuthorized, isUserSaved, !testingAuth {
-                        RewindView(router: .init(appRouter: appRouter))
-                    } else {
-                        WelcomeView(router: .init(appRouter: appRouter))
-                    }
+            RootView(router: appRouter)
+                .onAppear {
+                    let initial: AppRouter.Route = (isAuthorized && isUserSaved && !testingAuth) ? .rewind : .welcome
+                    appRouter.setInitial(initial)
                 }
-                .setUpNavigation(appRouter: appRouter)
-            }
-            .setupToast(toastController: toastController)
-            .environment(\.showToast, {
-                toastController.present(with: $0)
-            })
+                .setupToast(toastController: toastController)
+                .environment(\.showToast, {
+                    toastController.present(with: $0)
+                })
         }
     }
     
@@ -54,40 +49,6 @@ extension View {
     fileprivate func setupToast(toastController: ToastController) -> some View {
         self.overlay {
             ToastView(controller: toastController)
-        }
-    }
-    
-    fileprivate func setUpNavigation(appRouter: AppRouter) -> some View {
-        self.navigationDestination(for: AppRouter.Route.self) { route in
-            Group {
-                switch route {
-                case .account:
-                    AccountView(router: .init(appRouter: appRouter))
-                case .gallery:
-                    GalleryView(router: .init(appRouter: appRouter))
-                case .quoteCreation:
-                    QuoteCreationView()
-                case .mediaLoading:
-                    MediasUploadingView()
-                case let .mediaDetails(image):
-                    MediaDetailsView(image: image)
-                case let .email(flow):
-                    EmailInputView(flow: flow, router: .init(appRouter: appRouter))
-                case let .code(email, registrationID):
-                    CodeInputView(router: .init(appRouter: appRouter), email: email, registrationID: registrationID)
-                case let .password(flow, registrationID):
-                    PasswordInputView(flow: flow, router: .init(appRouter: appRouter), registrationID: registrationID)
-                case let .name(email, password, registrationID):
-                    NameInputView(router: .init(appRouter: appRouter), email: email, password: password, registrationID: registrationID)
-                case .rewind:
-                    RewindView(router: .init(appRouter: appRouter))
-                case .welcome:
-                    WelcomeView(router: .init(appRouter: appRouter))
-                case .map:
-                    RewindsMap()
-                }
-            }
-            .toolbar(.hidden)
         }
     }
 }


### PR DESCRIPTION
Такой дисмисс:

```
@Environment(\.dismiss)
private var dismiss
```

больше не работает, нужно явно делать дисмисс через роутер.

---

Почти везде выпилила

```
@Environment(\.dismiss)
private var dismiss
```

осталось только несколько мест:

<img width="640" alt="Screenshot 2025-05-16 at 15 33 47" src="https://github.com/user-attachments/assets/a64a4d22-5236-4c51-8d76-5cf78350eca8" />

\
У меня уже голова чуть кругом от этих дисмиссов, поэтому в этих местах либо доделаю позже, либо можешь сам доделать